### PR TITLE
Add unit and integration tests

### DIFF
--- a/agentserver/pyproject.toml
+++ b/agentserver/pyproject.toml
@@ -10,4 +10,5 @@ dependencies = [
     "requests>=2.31.0",
     "pydantic-ai>=0.0.14",
     "python-dotenv>=1.0.0",
+    "httpx>=0.27,<0.28",
 ]

--- a/agentserver/test_api.py
+++ b/agentserver/test_api.py
@@ -3,7 +3,9 @@
 import requests
 import json
 from datetime import datetime
+import pytest
 
+@pytest.mark.skip(reason="requires running server")
 def test_health_endpoint():
     """Test the health endpoint"""
     print("Testing health endpoint...")
@@ -18,7 +20,7 @@ def test_health_endpoint():
     except Exception as e:
         print(f"❌ Health check failed: {e}")
         return False
-
+@pytest.mark.skip(reason="requires running server")
 def test_analyze_endpoint():
     """Test the analyze endpoint with mock conversation and emotion timeline data"""
     print("\nTesting analyze endpoint...")

--- a/agentserver/tests/test_analyzer.py
+++ b/agentserver/tests/test_analyzer.py
@@ -1,0 +1,43 @@
+import sys
+import pathlib
+import types
+import asyncio
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+pydantic_ai_stub = types.ModuleType("pydantic_ai")
+
+class DummyAgent:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def run(self, prompt):
+        raise NotImplementedError
+
+pydantic_ai_stub.Agent = DummyAgent
+sys.modules.setdefault("pydantic_ai", pydantic_ai_stub)
+
+from agents import analyzer
+from models.assessment import AutismAssessmentResponse
+
+
+def test_create_mock_response_structure():
+    response = analyzer._create_mock_response()
+    assert isinstance(response, AutismAssessmentResponse)
+    eye = response.social_communication_markers.eye_contact
+    assert 0 <= eye.frequency_score <= 1
+    assert 0 <= response.aggregate_scores.overall_autism_likelihood <= 1
+
+
+def test_analyze_fallback_called(monkeypatch):
+    async def failing_run(prompt):
+        raise RuntimeError("boom")
+
+    sentinel = analyzer._create_mock_response()
+
+    monkeypatch.setattr(analyzer.autism_agent, "run", failing_run)
+    monkeypatch.setattr(analyzer, "_create_mock_response", lambda: sentinel)
+
+    result = asyncio.run(analyzer.analyze({}, {}))
+    assert result is sentinel

--- a/agentserver/tests/test_app.py
+++ b/agentserver/tests/test_app.py
@@ -1,0 +1,49 @@
+import sys
+import pathlib
+import types
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+pydantic_ai_stub = types.ModuleType("pydantic_ai")
+
+class DummyAgent:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def run(self, prompt):
+        raise NotImplementedError
+
+pydantic_ai_stub.Agent = DummyAgent
+sys.modules.setdefault("pydantic_ai", pydantic_ai_stub)
+
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+import main
+from agents import analyzer
+
+
+client = TestClient(main.app)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+def test_analyze_endpoint(monkeypatch):
+    sample = analyzer._create_mock_response()
+
+    async def fake_analyze(conversation_data, hume_data):
+        return sample
+
+    monkeypatch.setattr(main, "analyze", fake_analyze)
+
+    payload = {"conversation_data": {}, "hume_data": {}}
+    response = client.post("/analyze", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["aggregate_scores"]["overall_autism_likelihood"] == sample.aggregate_scores.overall_autism_likelihood


### PR DESCRIPTION
## Summary
- add httpx dependency for testing FastAPI endpoints
- skip manual API tests that require a running server
- add unit tests for analyzer fallback logic
- add integration tests for API endpoints

## Testing
- `cd agentserver && pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bcc44bfec0832aa2d10d098688600a