### PR TITLE
Improve assessment details UI presentation

### DIFF
--- a/next-js-streaming-example/components/AssessmentDetails.tsx
+++ b/next-js-streaming-example/components/AssessmentDetails.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+interface AssessmentData {
+  [key: string]: any;
+}
+
+const LABELS: Record<string, string> = {
+  overall_autism_likelihood: "Overall Autism Likelihood",
+  assessment_confidence: "Assessment Confidence",
+  social_communication_score: "Social Communication Score",
+  repetitive_behaviors_score: "Repetitive Behaviors Score",
+  sensory_processing_score: "Sensory Processing Score",
+  eye_contact_score: "Eye Contact Score",
+  facial_expression_score: "Facial Expression Score",
+  prosody_score: "Prosody Score",
+  vocal_characteristics_score: "Vocal Characteristics Score",
+  social_communication_deficits: "Social Communication Deficits",
+  restricted_repetitive_behaviors: "Restricted Repetitive Behaviors",
+  functional_impairment: "Functional Impairment",
+  support_level: "Support Level",
+  evaluation_priority: "Evaluation Priority",
+  primary_concerns: "Primary Concerns",
+  observed_strengths: "Observed Strengths",
+  key_recommendations: "Key Recommendations",
+  assessment_limitations: "Assessment Limitations",
+};
+
+const formatValue = (value: any) => {
+  if (typeof value === "number") {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  if (typeof value === "string") {
+    return value.replace(/_/g, " ");
+  }
+  return String(value);
+};
+
+export default function AssessmentDetails({ data }: { data: AssessmentData }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {Object.entries(LABELS).map(([key, label]) => {
+        const value = data[key];
+        if (value === undefined) return null;
+        return (
+          <div key={key} className="bg-white p-4 rounded border">
+            <div className="text-sm text-gray-500">{label}</div>
+            <div className="mt-1 font-medium text-gray-800">{formatValue(value)}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/next-js-streaming-example/pages/multimodel/index.tsx
+++ b/next-js-streaming-example/pages/multimodel/index.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react";
 import { FaceWidgets } from "../../components/widgets/FaceWidgets";
 import { ProsodyWidgets } from "../../components/widgets/ProsodyWidgets";
 import { BurstWidgets } from "../../components/widgets/BurstWidgets";
+import AssessmentDetails from "../../components/AssessmentDetails";
 import { Emotion } from "../../lib/data/emotion";
 import { AudioPrediction } from "../../lib/data/audioPrediction";
 
@@ -327,9 +328,9 @@ export default function MultiModelPage() {
             <summary className="cursor-pointer font-medium text-gray-700 hover:text-gray-900">
               View Full Assessment Details
             </summary>
-            <pre className="mt-4 text-xs text-gray-600 overflow-auto max-h-96 bg-white p-3 rounded border">
-              {JSON.stringify(analysisResult, null, 2)}
-            </pre>
+            <div className="mt-4">
+              <AssessmentDetails data={analysisResult} />
+            </div>
           </details>
         </div>
       )}


### PR DESCRIPTION
## Summary
- render full assessment data with new AssessmentDetails component
- replace raw JSON display with styled grid in multimodel results page

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build` *(fails: Cannot find module 'clsx')*


------
https://chatgpt.com/codex/tasks/task_b_68bccc59e564832aa863d0cf181cc6c1