### PR TITLE
Fix analyzer tests and add success path coverage

### DIFF
--- a/agentserver/tests/test_app.py
+++ b/agentserver/tests/test_app.py
@@ -46,4 +46,4 @@ def test_analyze_endpoint(monkeypatch):
     response = client.post("/analyze", json=payload)
     assert response.status_code == 200
     data = response.json()
-    assert data["aggregate_scores"]["overall_autism_likelihood"] == sample.aggregate_scores.overall_autism_likelihood
+    assert data["overall_autism_likelihood"] == sample.overall_autism_likelihood


### PR DESCRIPTION
## Summary
- align analyzer tests with `FlatAutismAssessment`
- add success-path test for analyzer
- update app tests to expect flattened response and include missing import

## Testing
- `cd agentserver && pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bcde7dc1dc832a9642fde35a7a16db