### PR TITLE
style: run black and ruff on agentserver

### DIFF
--- a/agentserver/main.py
+++ b/agentserver/main.py
@@ -19,6 +19,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.post("/analyze", response_model=FlatAutismAssessment)
 async def analyze_expressions(request: dict):
     print(f"🔄 Received analyze request at {datetime.now()}")
@@ -31,7 +32,7 @@ async def analyze_expressions(request: dict):
     print(f"📏 Total data size: {len(str(request))} chars")
 
     result = await analyze(conversation_data, hume_data)
-    
+
     print(f"✅ Analysis complete - likelihood: {result.overall_autism_likelihood:.3f}")
     return result
 

--- a/agentserver/models/flat_assessment.py
+++ b/agentserver/models/flat_assessment.py
@@ -1,40 +1,39 @@
 from pydantic import BaseModel
-from typing import List, Literal
-from datetime import datetime
+from typing import Literal
 
 
 class FlatAutismAssessment(BaseModel):
     """Flattened autism assessment response with minimal nesting for Gemini compatibility"""
-    
+
     # Basic metadata
     session_id: str
     timestamp: str
     analysis_version: str = "1.0"
-    
+
     # Core scores (all 0.0 to 1.0)
     overall_autism_likelihood: float
     assessment_confidence: float
-    
+
     # Main domain scores
     social_communication_score: float
     repetitive_behaviors_score: float
     sensory_processing_score: float
-    
+
     # Key behavioral indicators
     eye_contact_score: float
     facial_expression_score: float
     prosody_score: float
     vocal_characteristics_score: float
-    
+
     # DSM-5 aligned scores
     social_communication_deficits: float
     restricted_repetitive_behaviors: float
     functional_impairment: float
-    
+
     # Support level and recommendations
     support_level: Literal["level_1", "level_2", "level_3"]
     evaluation_priority: Literal["low", "moderate", "high", "urgent"]
-    
+
     # Text summaries
     primary_concerns: str
     observed_strengths: str

--- a/agentserver/models/simple_assessment.py
+++ b/agentserver/models/simple_assessment.py
@@ -1,30 +1,51 @@
 from pydantic import BaseModel, Field
-from typing import List, Literal
+from typing import Literal
 
 
 class SimplifiedAutismAssessment(BaseModel):
     """Simplified autism assessment response that works with Gemini's schema constraints"""
-    
+
     # Core assessment scores (0.0 to 1.0)
-    overall_autism_likelihood: float = Field(..., ge=0.0, le=1.0, description="Overall likelihood of autism spectrum disorder")
-    assessment_confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence in this assessment")
-    
+    overall_autism_likelihood: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Overall likelihood of autism spectrum disorder",
+    )
+    assessment_confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Confidence in this assessment"
+    )
+
     # Key domain scores
-    social_communication_score: float = Field(..., ge=0.0, le=1.0, description="Social communication difficulties")
-    repetitive_behaviors_score: float = Field(..., ge=0.0, le=1.0, description="Restricted and repetitive behaviors")
-    sensory_processing_score: float = Field(..., ge=0.0, le=1.0, description="Sensory processing differences")
-    
+    social_communication_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Social communication difficulties"
+    )
+    repetitive_behaviors_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Restricted and repetitive behaviors"
+    )
+    sensory_processing_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Sensory processing differences"
+    )
+
     # Support level estimate
-    support_level: Literal["minimal", "substantial", "very_substantial"] = Field(..., description="Estimated support needs level")
-    
+    support_level: Literal["minimal", "substantial", "very_substantial"] = Field(
+        ..., description="Estimated support needs level"
+    )
+
     # Professional recommendation
-    evaluation_priority: Literal["low", "moderate", "high", "urgent"] = Field(..., description="Priority for professional evaluation")
-    
+    evaluation_priority: Literal["low", "moderate", "high", "urgent"] = Field(
+        ..., description="Priority for professional evaluation"
+    )
+
     # Key observations (text summaries)
     primary_concerns: str = Field(..., description="Main areas of concern identified")
-    strengths_noted: str = Field(..., description="Strengths and positive behaviors observed")
+    strengths_noted: str = Field(
+        ..., description="Strengths and positive behaviors observed"
+    )
     recommendations: str = Field(..., description="Next steps and recommendations")
-    
+
     # Assessment limitations
-    data_quality: Literal["poor", "fair", "good", "excellent"] = Field(..., description="Quality of input data")
+    data_quality: Literal["poor", "fair", "good", "excellent"] = Field(
+        ..., description="Quality of input data"
+    )
     limitations: str = Field(..., description="Key limitations of this assessment")

--- a/agentserver/test_api.py
+++ b/agentserver/test_api.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime
 import pytest
 
+
 @pytest.mark.skip(reason="requires running server")
 def test_health_endpoint():
     """Test the health endpoint"""
@@ -20,6 +21,7 @@ def test_health_endpoint():
     except Exception as e:
         print(f"❌ Health check failed: {e}")
         return False
+
 
 @pytest.mark.skip(reason="requires running server")
 def test_analyze_endpoint():

--- a/agentserver/tests/test_analyzer.py
+++ b/agentserver/tests/test_analyzer.py
@@ -2,11 +2,11 @@ import sys
 import pathlib
 import types
 import asyncio
-import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 pydantic_ai_stub = types.ModuleType("pydantic_ai")
+
 
 class DummyAgent:
     def __init__(self, *args, **kwargs):
@@ -15,11 +15,12 @@ class DummyAgent:
     async def run(self, prompt):
         raise NotImplementedError
 
+
 pydantic_ai_stub.Agent = DummyAgent
 sys.modules.setdefault("pydantic_ai", pydantic_ai_stub)
 
-from agents import analyzer
-from models.assessment import AutismAssessmentResponse
+from agents import analyzer  # noqa: E402
+from models.assessment import AutismAssessmentResponse  # noqa: E402
 
 
 def test_create_mock_response_structure():

--- a/agentserver/tests/test_app.py
+++ b/agentserver/tests/test_app.py
@@ -7,12 +7,14 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 pydantic_ai_stub = types.ModuleType("pydantic_ai")
 
+
 class DummyAgent:
     def __init__(self, *args, **kwargs):
         pass
 
     async def run(self, prompt):
         raise NotImplementedError
+
 
 pydantic_ai_stub.Agent = DummyAgent
 sys.modules.setdefault("pydantic_ai", pydantic_ai_stub)
@@ -21,8 +23,8 @@ dotenv_stub = types.ModuleType("dotenv")
 dotenv_stub.load_dotenv = lambda: None
 sys.modules.setdefault("dotenv", dotenv_stub)
 
-import main
-from agents import analyzer
+import main  # noqa: E402
+from agents import analyzer  # noqa: E402
 
 
 client = TestClient(main.app)
@@ -46,4 +48,7 @@ def test_analyze_endpoint(monkeypatch):
     response = client.post("/analyze", json=payload)
     assert response.status_code == 200
     data = response.json()
-    assert data["aggregate_scores"]["overall_autism_likelihood"] == sample.aggregate_scores.overall_autism_likelihood
+    assert (
+        data["aggregate_scores"]["overall_autism_likelihood"]
+        == sample.aggregate_scores.overall_autism_likelihood
+    )


### PR DESCRIPTION
## Summary
- format agentserver Python files with Black
- fix lint errors and allow deferred imports with `# noqa: E402`

## Testing
- `ruff check agentserver`
- `pytest` *(fails: AssertionError, AttributeError, KeyError)*

------
https://chatgpt.com/codex/tasks/task_b_68bcdec98e04832a94a008ddb5398260