### PR TITLE
Run black and ruff

### DIFF
--- a/agentserver/agents/analyzer.py
+++ b/agentserver/agents/analyzer.py
@@ -1,7 +1,7 @@
-import os
 from datetime import datetime
 from typing import Dict, Any
 from dotenv import load_dotenv
+
 try:
     from pydantic_ai import Agent  # type: ignore
 except Exception as _e:  # noqa: N816
@@ -17,7 +17,9 @@ from models.flat_assessment import FlatAutismAssessment
 autism_agent = None
 
 
-async def analyze(conversation_data: Dict[str, Any], hume_data: Dict[str, Any]) -> FlatAutismAssessment:
+async def analyze(
+    conversation_data: Dict[str, Any], hume_data: Dict[str, Any]
+) -> FlatAutismAssessment:
     """
     Analyzes multi-modal data using PydanticAI with built-in retry handling.
     """
@@ -31,13 +33,15 @@ async def analyze(conversation_data: Dict[str, Any], hume_data: Dict[str, Any]) 
 
     # Build comprehensive analysis prompt
     # Extract transcript data for focused analysis
-    transcript_messages = conversation_data.get('transcript_messages', [])
+    transcript_messages = conversation_data.get("transcript_messages", [])
     transcript_text = ""
     if transcript_messages:
-        transcript_text = "\n".join([
-            f"[{msg.get('role', 'unknown')}]: {msg.get('speech', '')}" 
-            for msg in transcript_messages
-        ])
+        transcript_text = "\n".join(
+            [
+                f"[{msg.get('role', 'unknown')}]: {msg.get('speech', '')}"
+                for msg in transcript_messages
+            ]
+        )
 
     analysis_prompt = f"""
     AUTISM SPECTRUM ASSESSMENT REQUEST
@@ -106,7 +110,7 @@ async def analyze(conversation_data: Dict[str, Any], hume_data: Dict[str, Any]) 
         try:
             # Note: GEMINI_API_KEY is picked up from env by newer pydantic_ai
             autism_agent = Agent(
-                'gemini-2.5-pro',  # Use model string instead of GoogleModel class
+                "gemini-2.5-pro",  # Use model string instead of GoogleModel class
                 result_type=FlatAutismAssessment,
                 retries=3,
                 system_prompt="""You are an expert autism assessment specialist with deep knowledge of DSM-5 criteria, 
@@ -129,7 +133,7 @@ async def analyze(conversation_data: Dict[str, Any], hume_data: Dict[str, Any]) 
 
     if autism_agent is None:
         # pydantic_ai not available; return fallback to keep API responsive
-        if '_PYDANTIC_AI_IMPORT_ERROR' in globals():
+        if "_PYDANTIC_AI_IMPORT_ERROR" in globals():
             print(f"❌ pydantic_ai unavailable: {_PYDANTIC_AI_IMPORT_ERROR}")
         print("🔄 Returning fallback assessment response.")
         return _create_mock_response()
@@ -137,7 +141,9 @@ async def analyze(conversation_data: Dict[str, Any], hume_data: Dict[str, Any]) 
     try:
         print("🤖 Running PydanticAI agent with built-in retries...")
         result = await autism_agent.run(analysis_prompt)
-        assessment = result.data  # Changed from result.output to result.data for newer API
+        assessment = (
+            result.data
+        )  # Changed from result.output to result.data for newer API
         print("✅ Analysis successful")
         print(f"📈 Assessment confidence: {assessment.assessment_confidence:.3f}")
         print(f"🎯 Autism likelihood: {assessment.overall_autism_likelihood:.3f}")
@@ -147,36 +153,32 @@ async def analyze(conversation_data: Dict[str, Any], hume_data: Dict[str, Any]) 
         print(f"❌ PydanticAI analysis failed after retries: {e}")
         print("🔄 Generating fallback assessment...")
         return _create_mock_response()
-    
+
+
 def _create_mock_response() -> FlatAutismAssessment:
     """Fallback mock response if API fails"""
     import random
+
     return FlatAutismAssessment(
         session_id=f"fallback_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
         timestamp=datetime.now().isoformat(),
         analysis_version="1.0",
-        
         overall_autism_likelihood=random.uniform(0.4, 0.8),
         assessment_confidence=random.uniform(0.6, 0.8),
-        
         social_communication_score=random.uniform(0.3, 0.7),
         repetitive_behaviors_score=random.uniform(0.2, 0.6),
         sensory_processing_score=random.uniform(0.4, 0.8),
-        
         eye_contact_score=random.uniform(0.2, 0.6),
         facial_expression_score=random.uniform(0.3, 0.7),
         prosody_score=random.uniform(0.4, 0.8),
         vocal_characteristics_score=random.uniform(0.3, 0.7),
-        
         social_communication_deficits=random.uniform(0.4, 0.7),
         restricted_repetitive_behaviors=random.uniform(0.3, 0.6),
         functional_impairment=random.uniform(0.3, 0.6),
-        
         support_level="level_1",
         evaluation_priority="moderate",
-        
         primary_concerns="Limited data available - automated fallback response",
         observed_strengths="Unable to assess due to technical limitations",
         key_recommendations="Seek professional clinical assessment",
-        assessment_limitations="This is a fallback response due to API failure"
+        assessment_limitations="This is a fallback response due to API failure",
     )

--- a/agentserver/main.py
+++ b/agentserver/main.py
@@ -19,6 +19,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.post("/analyze", response_model=FlatAutismAssessment)
 async def analyze_expressions(request: dict):
     print(f"🔄 Received analyze request at {datetime.now()}")
@@ -31,7 +32,7 @@ async def analyze_expressions(request: dict):
     print(f"📏 Total data size: {len(str(request))} chars")
 
     result = await analyze(conversation_data, hume_data)
-    
+
     print(f"✅ Analysis complete - likelihood: {result.overall_autism_likelihood:.3f}")
     return result
 

--- a/agentserver/models/flat_assessment.py
+++ b/agentserver/models/flat_assessment.py
@@ -1,40 +1,39 @@
 from pydantic import BaseModel
-from typing import List, Literal
-from datetime import datetime
+from typing import Literal
 
 
 class FlatAutismAssessment(BaseModel):
     """Flattened autism assessment response with minimal nesting for Gemini compatibility"""
-    
+
     # Basic metadata
     session_id: str
     timestamp: str
     analysis_version: str = "1.0"
-    
+
     # Core scores (all 0.0 to 1.0)
     overall_autism_likelihood: float
     assessment_confidence: float
-    
+
     # Main domain scores
     social_communication_score: float
     repetitive_behaviors_score: float
     sensory_processing_score: float
-    
+
     # Key behavioral indicators
     eye_contact_score: float
     facial_expression_score: float
     prosody_score: float
     vocal_characteristics_score: float
-    
+
     # DSM-5 aligned scores
     social_communication_deficits: float
     restricted_repetitive_behaviors: float
     functional_impairment: float
-    
+
     # Support level and recommendations
     support_level: Literal["level_1", "level_2", "level_3"]
     evaluation_priority: Literal["low", "moderate", "high", "urgent"]
-    
+
     # Text summaries
     primary_concerns: str
     observed_strengths: str

--- a/agentserver/models/simple_assessment.py
+++ b/agentserver/models/simple_assessment.py
@@ -1,30 +1,51 @@
 from pydantic import BaseModel, Field
-from typing import List, Literal
+from typing import Literal
 
 
 class SimplifiedAutismAssessment(BaseModel):
     """Simplified autism assessment response that works with Gemini's schema constraints"""
-    
+
     # Core assessment scores (0.0 to 1.0)
-    overall_autism_likelihood: float = Field(..., ge=0.0, le=1.0, description="Overall likelihood of autism spectrum disorder")
-    assessment_confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence in this assessment")
-    
+    overall_autism_likelihood: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Overall likelihood of autism spectrum disorder",
+    )
+    assessment_confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Confidence in this assessment"
+    )
+
     # Key domain scores
-    social_communication_score: float = Field(..., ge=0.0, le=1.0, description="Social communication difficulties")
-    repetitive_behaviors_score: float = Field(..., ge=0.0, le=1.0, description="Restricted and repetitive behaviors")
-    sensory_processing_score: float = Field(..., ge=0.0, le=1.0, description="Sensory processing differences")
-    
+    social_communication_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Social communication difficulties"
+    )
+    repetitive_behaviors_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Restricted and repetitive behaviors"
+    )
+    sensory_processing_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Sensory processing differences"
+    )
+
     # Support level estimate
-    support_level: Literal["minimal", "substantial", "very_substantial"] = Field(..., description="Estimated support needs level")
-    
+    support_level: Literal["minimal", "substantial", "very_substantial"] = Field(
+        ..., description="Estimated support needs level"
+    )
+
     # Professional recommendation
-    evaluation_priority: Literal["low", "moderate", "high", "urgent"] = Field(..., description="Priority for professional evaluation")
-    
+    evaluation_priority: Literal["low", "moderate", "high", "urgent"] = Field(
+        ..., description="Priority for professional evaluation"
+    )
+
     # Key observations (text summaries)
     primary_concerns: str = Field(..., description="Main areas of concern identified")
-    strengths_noted: str = Field(..., description="Strengths and positive behaviors observed")
+    strengths_noted: str = Field(
+        ..., description="Strengths and positive behaviors observed"
+    )
     recommendations: str = Field(..., description="Next steps and recommendations")
-    
+
     # Assessment limitations
-    data_quality: Literal["poor", "fair", "good", "excellent"] = Field(..., description="Quality of input data")
+    data_quality: Literal["poor", "fair", "good", "excellent"] = Field(
+        ..., description="Quality of input data"
+    )
     limitations: str = Field(..., description="Key limitations of this assessment")

--- a/agentserver/test_api.py
+++ b/agentserver/test_api.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime
 import pytest
 
+
 @pytest.mark.skip(reason="requires running server")
 def test_health_endpoint():
     """Test the health endpoint"""
@@ -20,6 +21,7 @@ def test_health_endpoint():
     except Exception as e:
         print(f"❌ Health check failed: {e}")
         return False
+
 
 @pytest.mark.skip(reason="requires running server")
 def test_analyze_endpoint():

--- a/agentserver/tests/test_analyzer.py
+++ b/agentserver/tests/test_analyzer.py
@@ -2,11 +2,11 @@ import sys
 import pathlib
 import types
 import asyncio
-import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 pydantic_ai_stub = types.ModuleType("pydantic_ai")
+
 
 class DummyAgent:
     def __init__(self, *args, **kwargs):
@@ -14,6 +14,7 @@ class DummyAgent:
 
     async def run(self, prompt):
         raise NotImplementedError
+
 
 pydantic_ai_stub.Agent = DummyAgent
 sys.modules.setdefault("pydantic_ai", pydantic_ai_stub)

--- a/agentserver/tests/test_app.py
+++ b/agentserver/tests/test_app.py
@@ -7,12 +7,14 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 pydantic_ai_stub = types.ModuleType("pydantic_ai")
 
+
 class DummyAgent:
     def __init__(self, *args, **kwargs):
         pass
 
     async def run(self, prompt):
         raise NotImplementedError
+
 
 pydantic_ai_stub.Agent = DummyAgent
 sys.modules.setdefault("pydantic_ai", pydantic_ai_stub)


### PR DESCRIPTION
## Summary
- Format agentserver modules, models, and tests using black.
- Run ruff with autofix to clean up lint issues.

## Testing
- `black .`
- `ruff check . --fix` (fails: E402 Module level import not at top of file)
- `pytest` (fails: TypeError: Client.__init__() got an unexpected keyword argument 'app')

------
https://chatgpt.com/codex/tasks/task_b_68bce0b1be40832aa7d20b3584ca6cdd